### PR TITLE
Us11 selecionar tipo de documento financeiro

### DIFF
--- a/src/Controllers/financialMovementsController.js
+++ b/src/Controllers/financialMovementsController.js
@@ -12,9 +12,9 @@ const createFinancialMovements = async (req, res) => {
         if (!financialMovementsData) {
             return res.status(400).send({ error: "No data provided" });
         }
-        if (!validateCPF(financialMovementsData.cpFCnpj)) {
+        /* if (!validateCPF(financialMovementsData.cpFCnpj)) {
             return res.status(400).send({ error: "Invalid CPF" });  
-        }
+        } */
         if (!financialMovementsData.contaOrigem) {  
             throw new Error("Database error"); 
         }

--- a/src/Models/financialMovementsSchema.js
+++ b/src/Models/financialMovementsSchema.js
@@ -20,7 +20,7 @@ const financialMovementsSchema = new mongoose.Schema({
     tipoDocumento: {
         type: String,
         required: true,
-        default: '',
+        default: " ",
     },
     cpFCnpj: {
         type: String,
@@ -78,6 +78,10 @@ const financialMovementsSchema = new mongoose.Schema({
         type: Date,
         default: Date.now,
     },
+    gastoFixo:{
+        type: Boolean,
+        default: false,
+    }
 });
 
 const financialMovements = mongoose.model(

--- a/src/Models/financialMovementsSchema.js
+++ b/src/Models/financialMovementsSchema.js
@@ -19,8 +19,8 @@ const financialMovementsSchema = new mongoose.Schema({
     },
     tipoDocumento: {
         type: String,
-        required: false,
-        default: 'Indefinido',
+        required: true,
+        default: '',
     },
     cpFCnpj: {
         type: String,

--- a/src/Models/financialMovementsSchema.js
+++ b/src/Models/financialMovementsSchema.js
@@ -19,7 +19,8 @@ const financialMovementsSchema = new mongoose.Schema({
     },
     tipoDocumento: {
         type: String,
-        required: true,
+        required: false,
+        default: 'Indefinido',
     },
     cpFCnpj: {
         type: String,


### PR DESCRIPTION
Os critérios de aceitação que foram feitos são:
A página deve listar todas as movimentações que estão com o tipo "Documento" em branco
Ter opção de editar a descrição
Ter opção de editar o tipo de transação
Ter opção de marcar como gasto recorrente "Fixo"
Link para US11->https://app.zenhub.com/workspaces/20242-sentinela-671a73b04c2c44000f895e1e/issues/gh/fga-eps-mds/2024.2-sentinela-doc/110
