### PR TITLE
Us20 crud patrimônios

### DIFF
--- a/src/Controllers/LocalizacaoController.js
+++ b/src/Controllers/LocalizacaoController.js
@@ -1,0 +1,93 @@
+const Localizacao = require("../Models/LocalizacaoSchema");
+
+// const validateCPF = (cpf) => {
+//     return /\d{3}\.\d{3}\.\d{3}-\d{2}/.test(cpf);
+// };
+
+const createlocalizacao = async (req, res) => {
+    try {
+        console.log("Dados recebidos:", req.body);
+        const localizacaoData = req.body.localizacaoData;
+        if (!localizacaoData) {
+            return res.status(400).send({ error: "No data provided" });
+        }
+
+        // Criação da movimentação financeira
+        const localizacao = new Localizacao(
+            localizacaoData
+        );
+        await localizacao.save();
+
+        res.status(201).send(localizacao);
+    } catch (error) {
+        console.error("Error creating localizacao:", error.message);
+        return res.status(400).send({ error: error.message });
+    }
+};
+
+const getlocalizacao = async (req, res) => {
+    try {
+        const localizacao = await Localizacao.find({});
+        return res.status(200).send(localizacao);
+    } catch (error) {
+        return res.status(400).send(error);
+    }
+};
+
+const getlocalizacaoById = async (req, res) => {
+    try {
+        const localizacao = await Localizacao.findById(
+            req.params.id
+        );
+        if (!localizacao) {
+            return res
+                .status(404)
+                .send({ error: "Localizacao not found" });
+        }
+        return res.status(200).send(localizacao);
+    } catch (error) {
+        return res.status(400).send(error);
+    }
+};
+
+const deletelocalizacaoById = async (req, res) => {
+    try {
+        const deletedlocalizacao =
+            await Localizacao.findByIdAndDelete(req.params.id);
+        if (!deletedlocalizacao) {
+            return res
+                .status(404)
+                .send({ error: "Localizacao not found" });
+        }
+        return res.status(200).send(deletedlocalizacao);
+    } catch (error) {
+        return res.status(400).send(error);
+    }
+};
+
+const updatelocalizacaoById = async (req, res) => {
+    try {
+        const localizacao = await Localizacao.findById(
+            req.params.id
+        );
+        if (!localizacao) {
+            return res
+                .status(404)
+                .send({ error: "Localizacao not found" });
+        }
+        Object.assign(localizacao, req.body.localizacaoData);
+        localizacao.updatedAt = new Date();
+        await localizacao.save();
+        return res.status(200).send(localizacao);
+    } catch (error) {
+        return res.status(400).send(error);
+    }
+};
+
+module.exports = {
+    createlocalizacao,
+    getlocalizacao,
+    getlocalizacaoById,
+    deletelocalizacaoById,
+    updatelocalizacaoById,
+};

--- a/src/Controllers/LocalizacaoController.js
+++ b/src/Controllers/LocalizacaoController.js
@@ -13,9 +13,7 @@ const createlocalizacao = async (req, res) => {
         }
 
         // Criação da movimentação financeira
-        const localizacao = new Localizacao(
-            localizacaoData
-        );
+        const localizacao = new Localizacao(localizacaoData);
         await localizacao.save();
 
         res.status(201).send(localizacao);
@@ -36,13 +34,9 @@ const getlocalizacao = async (req, res) => {
 
 const getlocalizacaoById = async (req, res) => {
     try {
-        const localizacao = await Localizacao.findById(
-            req.params.id
-        );
+        const localizacao = await Localizacao.findById(req.params.id);
         if (!localizacao) {
-            return res
-                .status(404)
-                .send({ error: "Localizacao not found" });
+            return res.status(404).send({ error: "Localizacao not found" });
         }
         return res.status(200).send(localizacao);
     } catch (error) {
@@ -52,12 +46,11 @@ const getlocalizacaoById = async (req, res) => {
 
 const deletelocalizacaoById = async (req, res) => {
     try {
-        const deletedlocalizacao =
-            await Localizacao.findByIdAndDelete(req.params.id);
+        const deletedlocalizacao = await Localizacao.findByIdAndDelete(
+            req.params.id
+        );
         if (!deletedlocalizacao) {
-            return res
-                .status(404)
-                .send({ error: "Localizacao not found" });
+            return res.status(404).send({ error: "Localizacao not found" });
         }
         return res.status(200).send(deletedlocalizacao);
     } catch (error) {
@@ -67,13 +60,9 @@ const deletelocalizacaoById = async (req, res) => {
 
 const updatelocalizacaoById = async (req, res) => {
     try {
-        const localizacao = await Localizacao.findById(
-            req.params.id
-        );
+        const localizacao = await Localizacao.findById(req.params.id);
         if (!localizacao) {
-            return res
-                .status(404)
-                .send({ error: "Localizacao not found" });
+            return res.status(404).send({ error: "Localizacao not found" });
         }
         Object.assign(localizacao, req.body.localizacaoData);
         localizacao.updatedAt = new Date();

--- a/src/Controllers/patrimonioController.js
+++ b/src/Controllers/patrimonioController.js
@@ -13,9 +13,7 @@ const createpatrimonio = async (req, res) => {
         }
 
         // Criação da movimentação financeira
-        const patrimonio = new Patrimonio(
-            patrimonioData
-        );
+        const patrimonio = new Patrimonio(patrimonioData);
         await patrimonio.save();
 
         res.status(201).send(patrimonio);
@@ -36,13 +34,9 @@ const getpatrimonio = async (req, res) => {
 
 const getpatrimonioById = async (req, res) => {
     try {
-        const patrimonio = await Patrimonio.findById(
-            req.params.id
-        );
+        const patrimonio = await Patrimonio.findById(req.params.id);
         if (!patrimonio) {
-            return res
-                .status(404)
-                .send({ error: "Patrimonio not found" });
+            return res.status(404).send({ error: "Patrimonio not found" });
         }
         return res.status(200).send(patrimonio);
     } catch (error) {
@@ -52,12 +46,11 @@ const getpatrimonioById = async (req, res) => {
 
 const deletepatrimonioById = async (req, res) => {
     try {
-        const deletedpatrimonio =
-            await Patrimonio.findByIdAndDelete(req.params.id);
+        const deletedpatrimonio = await Patrimonio.findByIdAndDelete(
+            req.params.id
+        );
         if (!deletedpatrimonio) {
-            return res
-                .status(404)
-                .send({ error: "Patrimonio not found" });
+            return res.status(404).send({ error: "Patrimonio not found" });
         }
         return res.status(200).send(deletedpatrimonio);
     } catch (error) {
@@ -67,13 +60,9 @@ const deletepatrimonioById = async (req, res) => {
 
 const updatepatrimonioById = async (req, res) => {
     try {
-        const patrimonio = await Patrimonio.findById(
-            req.params.id
-        );
+        const patrimonio = await Patrimonio.findById(req.params.id);
         if (!patrimonio) {
-            return res
-                .status(404)
-                .send({ error: "Patrimonio not found" });
+            return res.status(404).send({ error: "Patrimonio not found" });
         }
         Object.assign(patrimonio, req.body.patrimonioData);
         patrimonio.updatedAt = new Date();

--- a/src/Controllers/patrimonioController.js
+++ b/src/Controllers/patrimonioController.js
@@ -1,0 +1,99 @@
+const Patrimonio = require("../Models/patrimonioSchema");
+
+// const validateCPF = (cpf) => {
+//     return /\d{3}\.\d{3}\.\d{3}-\d{2}/.test(cpf);
+// };
+
+const createpatrimonio = async (req, res) => {
+    try {
+        console.log("Dados recebidos:", req.body);
+        const patrimonioData = req.body.patrimonioData || {};
+        if (!patrimonioData) {
+            return res.status(400).send({ error: "No data provided" });
+        }
+        /* if (!validateCPF(financialMovementsData.cpFCnpj)) {
+            return res.status(400).send({ error: "Invalid CPF" });  
+        } */
+        if (!patrimonioData.nome) {
+            throw new Error("Database error");
+        }
+
+        // Criação da movimentação financeira
+        const patrimonio = new patrimonio(
+            patrimonioData
+        );
+        await patrimonio.save();
+
+        res.status(201).send(patrimonio);
+    } catch (error) {
+        console.error("Error creating patrimonio:", error.message);
+        return res.status(400).send({ error: error.message });
+    }
+};
+
+const getpatrimonio = async (req, res) => {
+    try {
+        const patrimonio = await Patrimonio.find({});
+        return res.status(200).send(patrimonio);
+    } catch (error) {
+        return res.status(400).send(error);
+    }
+};
+
+const getpatrimonioById = async (req, res) => {
+    try {
+        const patrimonio = await patrimonio.findById(
+            req.params.id
+        );
+        if (!patrimonio) {
+            return res
+                .status(404)
+                .send({ error: "Patrimonio not found" });
+        }
+        return res.status(200).send(patrimonio);
+    } catch (error) {
+        return res.status(400).send(error);
+    }
+};
+
+const deletepatrimonioById = async (req, res) => {
+    try {
+        const deletedpatrimonio =
+            await patrimonio.findByIdAndDelete(req.params.id);
+        if (!deletedpatrimonio) {
+            return res
+                .status(404)
+                .send({ error: "Patrimonio not found" });
+        }
+        return res.status(200).send(deletedpatrimonio);
+    } catch (error) {
+        return res.status(400).send(error);
+    }
+};
+
+const updatepatrimonioById = async (req, res) => {
+    try {
+        const patrimonio = await patrimonio.findById(
+            req.params.id
+        );
+        if (!patrimonio) {
+            return res
+                .status(404)
+                .send({ error: "Patrimonio not found" });
+        }
+        Object.assign(patrimonio, req.body.patrimonioData);
+        patrimonio.updatedAt = new Date();
+        await patrimonio.save();
+        return res.status(200).send(patrimonio);
+    } catch (error) {
+        return res.status(400).send(error);
+    }
+};
+
+module.exports = {
+    createpatrimonio,
+    getpatrimonio,
+    getpatrimonioById,
+    deletepatrimonioById,
+    updatepatrimonioById,
+};

--- a/src/Controllers/patrimonioController.js
+++ b/src/Controllers/patrimonioController.js
@@ -11,9 +11,6 @@ const createpatrimonio = async (req, res) => {
         if (!patrimonioData) {
             return res.status(400).send({ error: "No data provided" });
         }
-        if (!patrimonioData.nome) {
-            throw new Error("Database error");
-        }
 
         // Criação da movimentação financeira
         const patrimonio = new Patrimonio(
@@ -56,7 +53,7 @@ const getpatrimonioById = async (req, res) => {
 const deletepatrimonioById = async (req, res) => {
     try {
         const deletedpatrimonio =
-            await patrimonio.findByIdAndDelete(req.params.id);
+            await Patrimonio.findByIdAndDelete(req.params.id);
         if (!deletedpatrimonio) {
             return res
                 .status(404)
@@ -70,7 +67,7 @@ const deletepatrimonioById = async (req, res) => {
 
 const updatepatrimonioById = async (req, res) => {
     try {
-        const patrimonio = await patrimonio.findById(
+        const patrimonio = await Patrimonio.findById(
             req.params.id
         );
         if (!patrimonio) {

--- a/src/Controllers/patrimonioController.js
+++ b/src/Controllers/patrimonioController.js
@@ -11,15 +11,12 @@ const createpatrimonio = async (req, res) => {
         if (!patrimonioData) {
             return res.status(400).send({ error: "No data provided" });
         }
-        /* if (!validateCPF(financialMovementsData.cpFCnpj)) {
-            return res.status(400).send({ error: "Invalid CPF" });  
-        } */
         if (!patrimonioData.nome) {
             throw new Error("Database error");
         }
 
         // Criação da movimentação financeira
-        const patrimonio = new patrimonio(
+        const patrimonio = new Patrimonio(
             patrimonioData
         );
         await patrimonio.save();
@@ -42,7 +39,7 @@ const getpatrimonio = async (req, res) => {
 
 const getpatrimonioById = async (req, res) => {
     try {
-        const patrimonio = await patrimonio.findById(
+        const patrimonio = await Patrimonio.findById(
             req.params.id
         );
         if (!patrimonio) {

--- a/src/Controllers/patrimonioLocalizacaoController.js
+++ b/src/Controllers/patrimonioLocalizacaoController.js
@@ -7,7 +7,8 @@ const PatrimonioLocalizacao = require("../Models/patrimonioLocalizacaoSchema");
 const createpatrimonioLocalizacao = async (req, res) => {
     try {
         console.log("Dados recebidos:", req.body);
-        const patrimonioLocalizacaoData = req.body.patrimonioLocalizacaoData || {};
+        const patrimonioLocalizacaoData =
+            req.body.patrimonioLocalizacaoData || {};
         if (!patrimonioLocalizacaoData) {
             return res.status(400).send({ error: "No data provided" });
         }
@@ -71,11 +72,12 @@ const updatepatrimonioLocalizacaoById = async (req, res) => {
             req.params.id
         );
         if (!patrimonioLocalizacao) {
-            return res
-                .status(404)
-                .send({ error: "Patrimonio not found" });
+            return res.status(404).send({ error: "Patrimonio not found" });
         }
-        Object.assign(patrimonioLocalizacao, req.body.patrimonioLocalizacaoData);
+        Object.assign(
+            patrimonioLocalizacao,
+            req.body.patrimonioLocalizacaoData
+        );
         patrimonioLocalizacao.updatedAt = new Date();
         await patrimonioLocalizacao.save();
         return res.status(200).send(patrimonioLocalizacao);

--- a/src/Controllers/patrimonioLocalizacaoController.js
+++ b/src/Controllers/patrimonioLocalizacaoController.js
@@ -75,7 +75,7 @@ const updatepatrimonioLocalizacaoById = async (req, res) => {
                 .status(404)
                 .send({ error: "Patrimonio not found" });
         }
-        Object.assign(patrimonioLocalizacao, req.body.patrimonioData);
+        Object.assign(patrimonioLocalizacao, req.body.patrimonioLocalizacaoData);
         patrimonioLocalizacao.updatedAt = new Date();
         await patrimonioLocalizacao.save();
         return res.status(200).send(patrimonioLocalizacao);

--- a/src/Controllers/patrimonioLocalizacaoController.js
+++ b/src/Controllers/patrimonioLocalizacaoController.js
@@ -1,0 +1,93 @@
+const PatrimonioLocalizacao = require("../Models/patrimonioLocalizacaoSchema");
+
+// const validateCPF = (cpf) => {
+//     return /\d{3}\.\d{3}\.\d{3}-\d{2}/.test(cpf);
+// };
+
+const createpatrimonioLocalizacao = async (req, res) => {
+    try {
+        console.log("Dados recebidos:", req.body);
+        const patrimonioLocalizacaoData = req.body.patrimonioLocalizacaoData || {};
+        if (!patrimonioLocalizacaoData) {
+            return res.status(400).send({ error: "No data provided" });
+        }
+
+        // Criação da movimentação financeira
+        const patrimonioLocalizacao = new PatrimonioLocalizacao(
+            patrimonioLocalizacaoData
+        );
+        await patrimonioLocalizacao.save();
+
+        res.status(201).send(patrimonioLocalizacao);
+    } catch (error) {
+        console.error("Error creating patrimonio:", error.message);
+        return res.status(400).send({ error: error.message });
+    }
+};
+
+const getpatrimonioLocalizacao = async (req, res) => {
+    try {
+        const patrimonioLocalizacao = await PatrimonioLocalizacao.find({});
+        return res.status(200).send(patrimonioLocalizacao);
+    } catch (error) {
+        return res.status(400).send(error);
+    }
+};
+
+const getpatrimonioLocalizacaoById = async (req, res) => {
+    try {
+        const patrimonioLocalizacao = await PatrimonioLocalizacao.findById(
+            req.params.id
+        );
+        if (!patrimonioLocalizacao) {
+            return res
+                .status(404)
+                .send({ error: "PatrimonioLocalizacao not found" });
+        }
+        return res.status(200).send(patrimonioLocalizacao);
+    } catch (error) {
+        return res.status(400).send(error);
+    }
+};
+
+const deletepatrimonioLocalizacaoById = async (req, res) => {
+    try {
+        const deletedpatrimonioLocalizacao =
+            await PatrimonioLocalizacao.findByIdAndDelete(req.params.id);
+        if (!deletedpatrimonioLocalizacao) {
+            return res
+                .status(404)
+                .send({ error: "PatrimonioLocalizacao not found" });
+        }
+        return res.status(200).send(deletedpatrimonioLocalizacao);
+    } catch (error) {
+        return res.status(400).send(error);
+    }
+};
+
+const updatepatrimonioLocalizacaoById = async (req, res) => {
+    try {
+        const patrimonioLocalizacao = await PatrimonioLocalizacao.findById(
+            req.params.id
+        );
+        if (!patrimonioLocalizacao) {
+            return res
+                .status(404)
+                .send({ error: "Patrimonio not found" });
+        }
+        Object.assign(patrimonioLocalizacao, req.body.patrimonioData);
+        patrimonioLocalizacao.updatedAt = new Date();
+        await patrimonioLocalizacao.save();
+        return res.status(200).send(patrimonioLocalizacao);
+    } catch (error) {
+        return res.status(400).send(error);
+    }
+};
+
+module.exports = {
+    createpatrimonioLocalizacao,
+    getpatrimonioLocalizacao,
+    getpatrimonioLocalizacaoById,
+    deletepatrimonioLocalizacaoById,
+    updatepatrimonioLocalizacaoById,
+};

--- a/src/Models/LocalizacaoSchema.js
+++ b/src/Models/LocalizacaoSchema.js
@@ -1,0 +1,14 @@
+const mongoose = require("mongoose");
+
+const LocalizacaoSchema = new mongoose.Schema({
+    localizacao: {
+        type: String,
+        required: false, 
+    },
+});
+
+const Localizacao = mongoose.model(
+    "Localizacao",
+    LocalizacaoSchema
+);
+module.exports = Localizacao;

--- a/src/Models/LocalizacaoSchema.js
+++ b/src/Models/LocalizacaoSchema.js
@@ -3,12 +3,9 @@ const mongoose = require("mongoose");
 const LocalizacaoSchema = new mongoose.Schema({
     localizacao: {
         type: String,
-        required: false, 
+        required: false,
     },
 });
 
-const Localizacao = mongoose.model(
-    "Localizacao",
-    LocalizacaoSchema
-);
+const Localizacao = mongoose.model("Localizacao", LocalizacaoSchema);
 module.exports = Localizacao;

--- a/src/Models/patrimonioLocalizacaoSchema.js
+++ b/src/Models/patrimonioLocalizacaoSchema.js
@@ -3,17 +3,17 @@ const mongoose = require("mongoose");
 const patrimonioLocalizacaoSchema = new mongoose.Schema({
     numerodeEtiqueta: {
         type: Number,
-        min:0,
-        max:9999,
+        min: 0,
+        max: 9999,
         required: true,
     },
     de: {
         type: String,
-        required: false, 
+        required: false,
     },
     para: {
         type: String,
-        required: false, 
+        required: false,
     },
     data: {
         type: Date,

--- a/src/Models/patrimonioLocalizacaoSchema.js
+++ b/src/Models/patrimonioLocalizacaoSchema.js
@@ -1,0 +1,28 @@
+const mongoose = require("mongoose");
+
+const patrimonioLocalizacaoSchema = new mongoose.Schema({
+    numerodeEtiqueta: {
+        type: Number,
+        min:0,
+        max:9999,
+        required: true,
+    },
+    de: {
+        type: String,
+        required: false, 
+    },
+    para: {
+        type: String,
+        required: false, 
+    },
+    data: {
+        type: Date,
+        default: Date.now,
+    },
+});
+
+const patrimonioLocalizacao = mongoose.model(
+    "patrimonioLocalizacao",
+    patrimonioLocalizacaoSchema
+);
+module.exports = patrimonioLocalizacao;

--- a/src/Models/patrimonioSchema.js
+++ b/src/Models/patrimonioSchema.js
@@ -1,0 +1,44 @@
+const mongoose = require("mongoose");
+
+const patrimonioSchema = new mongoose.Schema({
+    nome: {
+        type: String,
+        required: true,
+    },
+    descricao: {
+        type: String,
+        required: false,
+    },
+    valor: {
+        type: Number,
+        required: true,
+    },
+    numerodeSerie: {
+        type: String,
+        required: false,
+    },
+    numerodeEtiqueta: {
+        type: Number,
+        min: 0,
+        max: 9999,
+        required: true,
+    },
+    localizacao: {
+        type: String,
+        required: false, /*deve ser alterado depois*/
+    },
+    doacao: {
+        type: Boolean,
+        default: false,
+    },
+    datadeCadastro: {
+        type: Date,
+        default: Date.now,
+    },
+});
+
+const patrimonio = mongoose.model(
+    "patrimonio",
+    patrimonioSchema
+);
+module.exports = patrimonio;

--- a/src/Models/patrimonioSchema.js
+++ b/src/Models/patrimonioSchema.js
@@ -25,7 +25,7 @@ const patrimonioSchema = new mongoose.Schema({
     },
     localizacao: {
         type: String,
-        required: false, /*deve ser alterado depois*/
+        required: false, 
     },
     doacao: {
         type: Boolean,

--- a/src/Models/patrimonioSchema.js
+++ b/src/Models/patrimonioSchema.js
@@ -25,7 +25,7 @@ const patrimonioSchema = new mongoose.Schema({
     },
     localizacao: {
         type: String,
-        required: false, 
+        required: false,
     },
     doacao: {
         type: Boolean,
@@ -37,8 +37,5 @@ const patrimonioSchema = new mongoose.Schema({
     },
 });
 
-const patrimonio = mongoose.model(
-    "patrimonio",
-    patrimonioSchema
-);
+const patrimonio = mongoose.model("patrimonio", patrimonioSchema);
 module.exports = patrimonio;

--- a/src/__tests__/LocalizacaoController.test.js
+++ b/src/__tests__/LocalizacaoController.test.js
@@ -74,8 +74,7 @@ describe("Localizacao API", () => {
     });
 
     it("should get localizacao", async () => {
-        const localizacaoModelCount =
-            await LocalizacaoModel.countDocuments({});
+        const localizacaoModelCount = await LocalizacaoModel.countDocuments({});
         const res = await request(app)
             .get("/localizacao")
             .set("Authorization", `Bearer ${mockedToken()}`);
@@ -137,10 +136,7 @@ describe("Localizacao API", () => {
             .set("Authorization", `Bearer ${mockedToken()}`);
 
         expect(res.status).toBe(404);
-        expect(res.body).toHaveProperty(
-            "error",
-            "Localizacao not found"
-        );
+        expect(res.body).toHaveProperty("error", "Localizacao not found");
     });
 
     it("should return 404 if localizacao not found on DELETE", async () => {
@@ -150,10 +146,7 @@ describe("Localizacao API", () => {
             .set("Authorization", `Bearer ${mockedToken()}`);
 
         expect(res.status).toBe(404);
-        expect(res.body).toHaveProperty(
-            "error",
-            "Localizacao not found"
-        );
+        expect(res.body).toHaveProperty("error", "Localizacao not found");
     });
     it("should update a localizacao with partial data", async () => {
         const { body: createdlocalizacao } = await request(app)

--- a/src/__tests__/LocalizacaoController.test.js
+++ b/src/__tests__/LocalizacaoController.test.js
@@ -1,0 +1,201 @@
+const request = require("supertest");
+const express = require("express");
+const mongoose = require("mongoose");
+const cors = require("cors");
+const routes = require("../routes");
+const LocalizacaoModel = require("../Models/LocalizacaoSchema");
+const { MongoMemoryServer } = require("mongodb-memory-server");
+const { mockedToken } = require("./utils.test");
+
+let mongoServer;
+let app = express();
+
+const corsOptions = {
+    origin: "*",
+    methods: "GET,HEAD,PUT,PATCH,POST,DELETE",
+};
+
+app.use(cors(corsOptions));
+app.use(express.json());
+app.use(express.urlencoded({ extended: true }));
+
+beforeAll(async () => {
+    mongoServer = await MongoMemoryServer.create();
+    const uri = mongoServer.getUri();
+
+    await mongoose.connect(uri, {
+        useNewUrlParser: true,
+        useUnifiedTopology: true,
+    });
+    app.use("/", routes);
+}, 30000);
+
+afterAll(async () => {
+    await mongoose.disconnect();
+    await mongoServer.stop();
+});
+
+afterEach(async () => {
+    await LocalizacaoModel.deleteMany({});
+});
+
+describe("Localizacao API", () => {
+    it("should create a new localizacao", async () => {
+        const res = await request(app)
+            .post("/localizacao/create")
+            .set("Authorization", `Bearer ${mockedToken()}`)
+            .send({
+                localizacaoData: {
+                    localizacao: "Copa",
+                },
+            }); // Enviar os dados dentro de LocalizacaoData
+
+        expect(res.status).toBe(201);
+        expect(res.body).toHaveProperty("localizacao", "Copa");
+    });
+
+    it("should get localizacao by id", async () => {
+        const { body: createdlocalizacao } = await request(app)
+            .post("/localizacao/create")
+            .set("Authorization", `Bearer ${mockedToken()}`)
+            .send({
+                localizacaoData: {
+                    localizacao: "Copa",
+                },
+                de: "Get By ID Mock",
+            });
+
+        const res = await request(app)
+            .get(`/localizacao/${createdlocalizacao._id}`)
+            .set("Authorization", `Bearer ${mockedToken()}`);
+
+        expect(res.body).toMatchObject(createdlocalizacao);
+        expect(res.status).toBe(200);
+    });
+
+    it("should get localizacao", async () => {
+        const localizacaoModelCount =
+            await LocalizacaoModel.countDocuments({});
+        const res = await request(app)
+            .get("/localizacao")
+            .set("Authorization", `Bearer ${mockedToken()}`);
+
+        expect(res.body.length).toBe(localizacaoModelCount);
+        expect(res.status).toBe(200);
+    });
+
+    it("should delete localizacao", async () => {
+        const { body: createdlocalizacao } = await request(app)
+            .post("/localizacao/create")
+            .set("Authorization", `Bearer ${mockedToken()}`)
+            .send({
+                localizacaoData: {
+                    localizacao: "Copa",
+                },
+                de: "Get By ID Mock",
+            });
+
+        const res = await request(app)
+            .delete(`/localizacao/delete/${createdlocalizacao._id}`)
+            .set("Authorization", `Bearer ${mockedToken()}`);
+
+        expect(res.body).toMatchObject(createdlocalizacao);
+        expect(res.status).toBe(200);
+    });
+
+    it("should update localizacao", async () => {
+        const { body: createdlocalizacao } = await request(app)
+            .post("/localizacao/create")
+            .set("Authorization", `Bearer ${mockedToken()}`)
+            .send({
+                localizacaoData: {
+                    localizacao: "Copa",
+                },
+                de: "Get By ID Mock",
+            });
+
+        const res = await request(app)
+            .patch(`/localizacao/update/${createdlocalizacao._id}`)
+            .set("Authorization", `Bearer ${mockedToken()}`);
+
+        expect(res.status).toBe(200);
+    });
+
+    it("should reject creating localizacao with missing data", async () => {
+        const res = await request(app)
+            .post("/localizacao/create")
+            .set("Authorization", `Bearer ${mockedToken()}`)
+            .send({}); // Enviar dados incompletos
+
+        expect(res.status).toBe(400);
+        expect(res.body).toHaveProperty("error");
+    });
+    it("should return 404 if localizacao not found on GET by ID", async () => {
+        const nonExistingId = "60f8e8b1d3b99c4b8c6c3bbd"; // ID fictício
+        const res = await request(app)
+            .get(`/localizacao/${nonExistingId}`)
+            .set("Authorization", `Bearer ${mockedToken()}`);
+
+        expect(res.status).toBe(404);
+        expect(res.body).toHaveProperty(
+            "error",
+            "Localizacao not found"
+        );
+    });
+
+    it("should return 404 if localizacao not found on DELETE", async () => {
+        const nonExistingId = "60f8e8b1d3b99c4b8c6c3bbd"; // ID fictício
+        const res = await request(app)
+            .delete(`/localizacao/delete/${nonExistingId}`)
+            .set("Authorization", `Bearer ${mockedToken()}`);
+
+        expect(res.status).toBe(404);
+        expect(res.body).toHaveProperty(
+            "error",
+            "Localizacao not found"
+        );
+    });
+    it("should update a localizacao with partial data", async () => {
+        const { body: createdlocalizacao } = await request(app)
+            .post("/localizacao/create")
+            .set("Authorization", `Bearer ${mockedToken()}`)
+            .send({
+                localizacaoData: {
+                    localizacao: "Copa",
+                },
+                de: "Get By ID Mock",
+            });
+
+        const updatedData = {
+            localizacao: "Espaço",
+        };
+
+        const res = await request(app)
+            .patch(`/localizacao/update/${createdlocalizacao._id}`)
+            .set("Authorization", `Bearer ${mockedToken()}`)
+            .send({ localizacaoData: updatedData });
+
+        expect(res.status).toBe(200);
+        expect(res.body).toHaveProperty("localizacao", "Espaço");
+    });
+
+    it("should update 'para' status", async () => {
+        const { body: createdlocalizacao } = await request(app)
+            .post("/localizacao/create")
+            .set("Authorization", `Bearer ${mockedToken()}`)
+            .send({
+                localizacaoData: {
+                    localizacao: "Copa",
+                },
+                de: "Get By ID Mock",
+            });
+
+        const res = await request(app)
+            .patch(`/localizacao/update/${createdlocalizacao._id}`)
+            .set("Authorization", `Bearer ${mockedToken()}`) // Atualize o caminho da rota
+            .send({ localizacaoData: { localizacao: "Casa" } });
+
+        expect(res.status).toBe(200);
+        expect(res.body).toHaveProperty("localizacao", "Casa");
+    });
+});

--- a/src/__tests__/patrimonioController.test.js
+++ b/src/__tests__/patrimonioController.test.js
@@ -1,0 +1,247 @@
+const request = require("supertest");
+const express = require("express");
+const mongoose = require("mongoose");
+const cors = require("cors");
+const routes = require("../routes");
+const patrimonioModel = require("../Models/patrimonioSchema");
+const { MongoMemoryServer } = require("mongodb-memory-server");
+const { mockedToken } = require("./utils.test");
+
+let mongoServer;
+let app = express();
+
+const corsOptions = {
+    origin: "*",
+    methods: "GET,HEAD,PUT,PATCH,POST,DELETE",
+};
+
+app.use(cors(corsOptions));
+app.use(express.json());
+app.use(express.urlencoded({ extended: true }));
+
+beforeAll(async () => {
+    mongoServer = await MongoMemoryServer.create();
+    const uri = mongoServer.getUri();
+
+    await mongoose.connect(uri, {
+        useNewUrlParser: true,
+        useUnifiedTopology: true,
+    });
+    app.use("/", routes);
+}, 30000);
+
+afterAll(async () => {
+    await mongoose.disconnect();
+    await mongoServer.stop();
+});
+
+afterEach(async () => {
+    await patrimonioModel.deleteMany({});
+});
+
+describe("Patrimonio API", () => {
+    it("should create a new patrimonio", async () => {
+        const res = await request(app)
+            .post("/patrimonio/create")
+            .set("Authorization", `Bearer ${mockedToken()}`)
+            .send({
+                patrimonioData: {
+                    nome: "Computador X",
+                    descricao: "Computador usado",
+                    valor: 200,
+                    numerodeSerie: "2CFF4A",
+                    numerodeEtiqueta: 5,
+                    localizacao: "Copa",
+                    doacao: false,
+                    datadeCadastro: new Date(),
+                },
+            }); // Enviar os dados dentro de patrimonioData
+
+        expect(res.status).toBe(201);
+        expect(res.body).toHaveProperty("nome", "Computador X");
+    });
+
+    it("should get patrimonio by id", async () => {
+        const { body: createdpatrimonio } = await request(app)
+            .post("/patrimonio/create")
+            .set("Authorization", `Bearer ${mockedToken()}`)
+            .send({
+                patrimonioData: {
+                    nome: "Computador X",
+                    descricao: "Computador usado",
+                    valor: 200,
+                    numerodeSerie: "2CFF4A",
+                    numerodeEtiqueta: 5,
+                    localizacao: "Copa",
+                    doacao: false,
+                    datadeCadastro: new Date(),
+                },
+                descricao: "Get By ID Mock",
+            });
+
+        const res = await request(app)
+            .get(`/patrimonio/${createdpatrimonio._id}`)
+            .set("Authorization", `Bearer ${mockedToken()}`);
+
+        expect(res.body).toMatchObject(createdpatrimonio);
+        expect(res.status).toBe(200);
+    });
+
+    it("should get patrimonio", async () => {
+        const patrimonioModelCount =
+            await patrimonioModel.countDocuments({});
+        const res = await request(app)
+            .get("/patrimonio")
+            .set("Authorization", `Bearer ${mockedToken()}`);
+
+        expect(res.body.length).toBe(patrimonioModelCount);
+        expect(res.status).toBe(200);
+    });
+
+    it("should delete patrimonio", async () => {
+        const { body: createdpatrimonio } = await request(app)
+            .post("/patrimonio/create")
+            .set("Authorization", `Bearer ${mockedToken()}`)
+            .send({
+                patrimonioData: {
+                    nome: "Computador X",
+                    descricao: "Computador usado",
+                    valor: 200,
+                    numerodeSerie: "2CFF4A",
+                    numerodeEtiqueta: 5,
+                    localizacao: "Copa",
+                    doacao: false,
+                    datadeCadastro: new Date(),
+                },
+                nome: "Delete By ID Mock",
+            });
+
+        const res = await request(app)
+            .delete(`/patrimonio/delete/${createdpatrimonio._id}`)
+            .set("Authorization", `Bearer ${mockedToken()}`);
+
+        expect(res.body).toMatchObject(createdpatrimonio);
+        expect(res.status).toBe(200);
+    });
+
+    it("should update patrimonio", async () => {
+        const { body: createdpatrimonio } = await request(app)
+            .post("/patrimonio/create")
+            .set("Authorization", `Bearer ${mockedToken()}`)
+            .send({
+                patrimonioData: {
+                    nome: "Computador X",
+                    descricao: "Computador usado",
+                    valor: 200,
+                    numerodeSerie: "2CFF4A",
+                    numerodeEtiqueta: 5,
+                    localizacao: "Copa",
+                    doacao: false,
+                    datadeCadastro: new Date(),
+                },
+                nome: "Update By ID Mock",
+            });
+
+        const res = await request(app)
+            .patch(`/patrimonio/update/${createdpatrimonio._id}`)
+            .set("Authorization", `Bearer ${mockedToken()}`);
+
+        expect(res.status).toBe(200);
+    });
+
+    it("should reject creating patrimonio with missing data", async () => {
+        const res = await request(app)
+            .post("/patrimonio/create")
+            .set("Authorization", `Bearer ${mockedToken()}`)
+            .send({}); // Enviar dados incompletos
+
+        expect(res.status).toBe(400);
+        expect(res.body).toHaveProperty("error");
+    });
+    it("should return 404 if patrimonio not found on GET by ID", async () => {
+        const nonExistingId = "60f8e8b1d3b99c4b8c6c3bbd"; // ID fictício
+        const res = await request(app)
+            .get(`/patrimonio/${nonExistingId}`)
+            .set("Authorization", `Bearer ${mockedToken()}`);
+
+        expect(res.status).toBe(404);
+        expect(res.body).toHaveProperty(
+            "error",
+            "Patrimonio not found"
+        );
+    });
+
+    it("should return 404 if patrimonio not found on DELETE", async () => {
+        const nonExistingId = "60f8e8b1d3b99c4b8c6c3bbd"; // ID fictício
+        const res = await request(app)
+            .delete(`/patrimonio/delete/${nonExistingId}`)
+            .set("Authorization", `Bearer ${mockedToken()}`);
+
+        expect(res.status).toBe(404);
+        expect(res.body).toHaveProperty(
+            "error",
+            "Patrimonio not found"
+        );
+    });
+    it("should update a patrimonio with partial data", async () => {
+        const { body: createdpatrimonio } = await request(app)
+            .post("/patrimonio/create")
+            .set("Authorization", `Bearer ${mockedToken()}`)
+            .send({
+                patrimonioData: {
+                    nome: "Computador X",
+                    descricao: "Computador usado",
+                    valor: 200,
+                    numerodeSerie: "2CFF4A",
+                    numerodeEtiqueta: 5,
+                    localizacao: "Copa",
+                    doacao: false,
+                    datadeCadastro: new Date(),
+                },
+                nome: "Update By ID Mock",
+            });
+
+        const updatedData = {
+            nome: "Computador X Atualizado",
+            valor: 1200,
+            numerodeEtiqueta: 23,
+        };
+
+        const res = await request(app)
+            .patch(`/patrimonio/update/${createdpatrimonio._id}`)
+            .set("Authorization", `Bearer ${mockedToken()}`)
+            .send({ patrimonioData: updatedData });
+
+        expect(res.status).toBe(200);
+        expect(res.body).toHaveProperty("nome", "Computador X Atualizado");
+        expect(res.body).toHaveProperty("valor", 1200);
+        expect(res.body).toHaveProperty("numerodeEtiqueta", 23);
+    });
+
+    it("should update 'doacao' status", async () => {
+        const { body: createdpatrimonio } = await request(app)
+            .post("/patrimonio/create")
+            .set("Authorization", `Bearer ${mockedToken()}`)
+            .send({
+                patrimonioData: {
+                    nome: "Computador X",
+                    descricao: "Computador usado",
+                    valor: 200,
+                    numerodeSerie: "2CFF4A",
+                    numerodeEtiqueta: 5,
+                    localizacao: "Copa",
+                    doacao: false,
+                    datadeCadastro: new Date(),
+                },
+                nome: "Update By ID Mock",
+            });
+
+        const res = await request(app)
+            .patch(`/patrimonio/update/${createdpatrimonio._id}`)
+            .set("Authorization", `Bearer ${mockedToken()}`) // Atualize o caminho da rota
+            .send({ patrimonioData: { doacao: true } });
+
+        expect(res.status).toBe(200);
+        expect(res.body).toHaveProperty("doacao", true);
+    });
+});

--- a/src/__tests__/patrimonioController.test.js
+++ b/src/__tests__/patrimonioController.test.js
@@ -88,8 +88,7 @@ describe("Patrimonio API", () => {
     });
 
     it("should get patrimonio", async () => {
-        const patrimonioModelCount =
-            await patrimonioModel.countDocuments({});
+        const patrimonioModelCount = await patrimonioModel.countDocuments({});
         const res = await request(app)
             .get("/patrimonio")
             .set("Authorization", `Bearer ${mockedToken()}`);
@@ -165,10 +164,7 @@ describe("Patrimonio API", () => {
             .set("Authorization", `Bearer ${mockedToken()}`);
 
         expect(res.status).toBe(404);
-        expect(res.body).toHaveProperty(
-            "error",
-            "Patrimonio not found"
-        );
+        expect(res.body).toHaveProperty("error", "Patrimonio not found");
     });
 
     it("should return 404 if patrimonio not found on DELETE", async () => {
@@ -178,10 +174,7 @@ describe("Patrimonio API", () => {
             .set("Authorization", `Bearer ${mockedToken()}`);
 
         expect(res.status).toBe(404);
-        expect(res.body).toHaveProperty(
-            "error",
-            "Patrimonio not found"
-        );
+        expect(res.body).toHaveProperty("error", "Patrimonio not found");
     });
     it("should update a patrimonio with partial data", async () => {
         const { body: createdpatrimonio } = await request(app)

--- a/src/__tests__/patrimonioLocalizacaoController.test.js
+++ b/src/__tests__/patrimonioLocalizacaoController.test.js
@@ -105,7 +105,9 @@ describe("PatrimonioLocalizacao API", () => {
             });
 
         const res = await request(app)
-            .delete(`/patrimonioLocalizacao/delete/${createdpatrimonioLocalizacao._id}`)
+            .delete(
+                `/patrimonioLocalizacao/delete/${createdpatrimonioLocalizacao._id}`
+            )
             .set("Authorization", `Bearer ${mockedToken()}`);
 
         expect(res.body).toMatchObject(createdpatrimonioLocalizacao);
@@ -127,7 +129,9 @@ describe("PatrimonioLocalizacao API", () => {
             });
 
         const res = await request(app)
-            .patch(`/patrimonioLocalizacao/update/${createdpatrimonioLocalizacao._id}`)
+            .patch(
+                `/patrimonioLocalizacao/update/${createdpatrimonioLocalizacao._id}`
+            )
             .set("Authorization", `Bearer ${mockedToken()}`);
 
         expect(res.status).toBe(200);
@@ -188,7 +192,9 @@ describe("PatrimonioLocalizacao API", () => {
         };
 
         const res = await request(app)
-            .patch(`/patrimonioLocalizacao/update/${createdpatrimonioLocalizacao._id}`)
+            .patch(
+                `/patrimonioLocalizacao/update/${createdpatrimonioLocalizacao._id}`
+            )
             .set("Authorization", `Bearer ${mockedToken()}`)
             .send({ patrimonioLocalizacaoData: updatedData });
 
@@ -213,7 +219,9 @@ describe("PatrimonioLocalizacao API", () => {
             });
 
         const res = await request(app)
-            .patch(`/patrimonioLocalizacao/update/${createdpatrimonioLocalizacao._id}`)
+            .patch(
+                `/patrimonioLocalizacao/update/${createdpatrimonioLocalizacao._id}`
+            )
             .set("Authorization", `Bearer ${mockedToken()}`) // Atualize o caminho da rota
             .send({ patrimonioLocalizacaoData: { para: "Casa" } });
 

--- a/src/__tests__/patrimonioLocalizacaoController.test.js
+++ b/src/__tests__/patrimonioLocalizacaoController.test.js
@@ -1,0 +1,223 @@
+const request = require("supertest");
+const express = require("express");
+const mongoose = require("mongoose");
+const cors = require("cors");
+const routes = require("../routes");
+const patrimonioLocalizacaoModel = require("../Models/patrimonioLocalizacaoSchema");
+const { MongoMemoryServer } = require("mongodb-memory-server");
+const { mockedToken } = require("./utils.test");
+
+let mongoServer;
+let app = express();
+
+const corsOptions = {
+    origin: "*",
+    methods: "GET,HEAD,PUT,PATCH,POST,DELETE",
+};
+
+app.use(cors(corsOptions));
+app.use(express.json());
+app.use(express.urlencoded({ extended: true }));
+
+beforeAll(async () => {
+    mongoServer = await MongoMemoryServer.create();
+    const uri = mongoServer.getUri();
+
+    await mongoose.connect(uri, {
+        useNewUrlParser: true,
+        useUnifiedTopology: true,
+    });
+    app.use("/", routes);
+}, 30000);
+
+afterAll(async () => {
+    await mongoose.disconnect();
+    await mongoServer.stop();
+});
+
+afterEach(async () => {
+    await patrimonioLocalizacaoModel.deleteMany({});
+});
+
+describe("PatrimonioLocalizacao API", () => {
+    it("should create a new patrimonioLocalizacao", async () => {
+        const res = await request(app)
+            .post("/patrimonioLocalizacao/create")
+            .set("Authorization", `Bearer ${mockedToken()}`)
+            .send({
+                patrimonioLocalizacaoData: {
+                    de: "Presidencia",
+                    para: "Copa",
+                    numerodeEtiqueta: 5,
+                    datadeCadastro: new Date(),
+                },
+            }); // Enviar os dados dentro de patrimonioLocalizacaoData
+
+        expect(res.status).toBe(201);
+        expect(res.body).toHaveProperty("numerodeEtiqueta", 5);
+    });
+
+    it("should get patrimonioLocalizacao by id", async () => {
+        const { body: createdpatrimonioLocalizacao } = await request(app)
+            .post("/patrimonioLocalizacao/create")
+            .set("Authorization", `Bearer ${mockedToken()}`)
+            .send({
+                patrimonioLocalizacaoData: {
+                    de: "Presidencia",
+                    para: "Copa",
+                    numerodeEtiqueta: 5,
+                    datadeCadastro: new Date(),
+                },
+                de: "Get By ID Mock",
+            });
+
+        const res = await request(app)
+            .get(`/patrimonioLocalizacao/${createdpatrimonioLocalizacao._id}`)
+            .set("Authorization", `Bearer ${mockedToken()}`);
+
+        expect(res.body).toMatchObject(createdpatrimonioLocalizacao);
+        expect(res.status).toBe(200);
+    });
+
+    it("should get patrimonioLocalizacao", async () => {
+        const patrimonioLocalizacaoModelCount =
+            await patrimonioLocalizacaoModel.countDocuments({});
+        const res = await request(app)
+            .get("/patrimonioLocalizacao")
+            .set("Authorization", `Bearer ${mockedToken()}`);
+
+        expect(res.body.length).toBe(patrimonioLocalizacaoModelCount);
+        expect(res.status).toBe(200);
+    });
+
+    it("should delete patrimonioLocalizacao", async () => {
+        const { body: createdpatrimonioLocalizacao } = await request(app)
+            .post("/patrimonioLocalizacao/create")
+            .set("Authorization", `Bearer ${mockedToken()}`)
+            .send({
+                patrimonioLocalizacaoData: {
+                    de: "Presidencia",
+                    para: "Copa",
+                    numerodeEtiqueta: 5,
+                    datadeCadastro: new Date(),
+                },
+                de: "Delete By ID Mock",
+            });
+
+        const res = await request(app)
+            .delete(`/patrimonioLocalizacao/delete/${createdpatrimonioLocalizacao._id}`)
+            .set("Authorization", `Bearer ${mockedToken()}`);
+
+        expect(res.body).toMatchObject(createdpatrimonioLocalizacao);
+        expect(res.status).toBe(200);
+    });
+
+    it("should update patrimonioLocalizacao", async () => {
+        const { body: createdpatrimonioLocalizacao } = await request(app)
+            .post("/patrimonioLocalizacao/create")
+            .set("Authorization", `Bearer ${mockedToken()}`)
+            .send({
+                patrimonioLocalizacaoData: {
+                    de: "Presidencia",
+                    para: "Copa",
+                    numerodeEtiqueta: 5,
+                    datadeCadastro: new Date(),
+                },
+                de: "Update By ID Mock",
+            });
+
+        const res = await request(app)
+            .patch(`/patrimonioLocalizacao/update/${createdpatrimonioLocalizacao._id}`)
+            .set("Authorization", `Bearer ${mockedToken()}`);
+
+        expect(res.status).toBe(200);
+    });
+
+    it("should reject creating patrimonioLocalizacao with missing data", async () => {
+        const res = await request(app)
+            .post("/patrimonioLocalizacao/create")
+            .set("Authorization", `Bearer ${mockedToken()}`)
+            .send({}); // Enviar dados incompletos
+
+        expect(res.status).toBe(400);
+        expect(res.body).toHaveProperty("error");
+    });
+    it("should return 404 if patrimonioLocalizacao not found on GET by ID", async () => {
+        const nonExistingId = "60f8e8b1d3b99c4b8c6c3bbd"; // ID fictício
+        const res = await request(app)
+            .get(`/patrimonioLocalizacao/${nonExistingId}`)
+            .set("Authorization", `Bearer ${mockedToken()}`);
+
+        expect(res.status).toBe(404);
+        expect(res.body).toHaveProperty(
+            "error",
+            "PatrimonioLocalizacao not found"
+        );
+    });
+
+    it("should return 404 if patrimonioLocalizacao not found on DELETE", async () => {
+        const nonExistingId = "60f8e8b1d3b99c4b8c6c3bbd"; // ID fictício
+        const res = await request(app)
+            .delete(`/patrimonioLocalizacao/delete/${nonExistingId}`)
+            .set("Authorization", `Bearer ${mockedToken()}`);
+
+        expect(res.status).toBe(404);
+        expect(res.body).toHaveProperty(
+            "error",
+            "PatrimonioLocalizacao not found"
+        );
+    });
+    it("should update a patrimonioLocalizacao with partial data", async () => {
+        const { body: createdpatrimonioLocalizacao } = await request(app)
+            .post("/patrimonioLocalizacao/create")
+            .set("Authorization", `Bearer ${mockedToken()}`)
+            .send({
+                patrimonioLocalizacaoData: {
+                    de: "Presidencia",
+                    para: "Copa",
+                    numerodeEtiqueta: 5,
+                    datadeCadastro: new Date(),
+                },
+                de: "Update By ID Mock",
+            });
+
+        const updatedData = {
+            de: "Copa",
+            para: "Espaço",
+            numerodeEtiqueta: 23,
+        };
+
+        const res = await request(app)
+            .patch(`/patrimonioLocalizacao/update/${createdpatrimonioLocalizacao._id}`)
+            .set("Authorization", `Bearer ${mockedToken()}`)
+            .send({ patrimonioLocalizacaoData: updatedData });
+
+        expect(res.status).toBe(200);
+        expect(res.body).toHaveProperty("de", "Copa");
+        expect(res.body).toHaveProperty("para", "Espaço");
+        expect(res.body).toHaveProperty("numerodeEtiqueta", 23);
+    });
+
+    it("should update 'para' status", async () => {
+        const { body: createdpatrimonioLocalizacao } = await request(app)
+            .post("/patrimonioLocalizacao/create")
+            .set("Authorization", `Bearer ${mockedToken()}`)
+            .send({
+                patrimonioLocalizacaoData: {
+                    de: "Presidencia",
+                    para: "Copa",
+                    numerodeEtiqueta: 5,
+                    datadeCadastro: new Date(),
+                },
+                de: "Update By ID Mock",
+            });
+
+        const res = await request(app)
+            .patch(`/patrimonioLocalizacao/update/${createdpatrimonioLocalizacao._id}`)
+            .set("Authorization", `Bearer ${mockedToken()}`) // Atualize o caminho da rota
+            .send({ patrimonioLocalizacaoData: { para: "Casa" } });
+
+        expect(res.status).toBe(200);
+        expect(res.body).toHaveProperty("para", "Casa");
+    });
+});

--- a/src/index.js
+++ b/src/index.js
@@ -45,17 +45,6 @@ const getFinancialMovementsFromDatabase = async () => {
         throw error;
     }
 };
-
-const getpatrimonioFromDatabase = async () => {
-    try {
-        const patrimonio = await Patrimonio.find(); // Verifique se este modelo está correto
-        return patrimonio;
-    } catch (error) {
-        console.error("Erro ao buscar patrimonio:", error);
-        throw error;
-    }
-};
-
 app.get("/download-financial-report", async (req, res) => {
     try {
         const { format } = req.query;

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,6 @@ const mongoose = require("mongoose");
 const cors = require("cors");
 const routes = require("./routes");
 const FinancialMovements = require("./Models/financialMovementsSchema");
-const Patrimonio = require("./Models/patrimonioSchema");
 const { generateFinancialReportPDF } = require("./Models/pdfGenerator");
 const { generateFinancialReportCSV } = require("./Models/csvGenerator");
 

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ const mongoose = require("mongoose");
 const cors = require("cors");
 const routes = require("./routes");
 const FinancialMovements = require("./Models/financialMovementsSchema");
+const Patrimonio = require("./Models/patrimonioSchema");
 const { generateFinancialReportPDF } = require("./Models/pdfGenerator");
 const { generateFinancialReportCSV } = require("./Models/csvGenerator");
 
@@ -41,6 +42,16 @@ const getFinancialMovementsFromDatabase = async () => {
         return financialMovements;
     } catch (error) {
         console.error("Erro ao buscar movimentações financeiras:", error);
+        throw error;
+    }
+};
+
+const getpatrimonioFromDatabase = async () => {
+    try {
+        const patrimonio = await Patrimonio.find(); // Verifique se este modelo está correto
+        return patrimonio;
+    } catch (error) {
+        console.error("Erro ao buscar patrimonio:", error);
         throw error;
     }
 };

--- a/src/routes.js
+++ b/src/routes.js
@@ -5,6 +5,7 @@ const supplierFormController = require("./Controllers/supplierFormController");
 const financialMovementsController = require("./Controllers/financialMovementsController");
 const patrimonioController = require("./Controllers/patrimonioController");
 const financialReportController = require("./Controllers/financialReportController");
+const patrimonioLocalizacaoController = require("./Controllers/patrimonioLocalizacaoController")
 const { checkPermissions } = require("./Middlewares/accessControlMiddleware");
 
 // Rotas Contas Bancárias
@@ -117,6 +118,32 @@ routes.patch(
     "/patrimonio/update/:id",
     checkPermissions("movimentacao_financeira_editar"),
     patrimonioController.updatepatrimonioById
+);
+
+routes.post(
+    "/patrimonioLocalizacao/create",
+    checkPermissions("movimentacao_financeira_criar"),
+    patrimonioLocalizacaoController.createpatrimonioLocalizacao
+);
+routes.get(
+    "/patrimonioLocalizacao",
+    checkPermissions("movimentacao_financeira_visualizar"),
+    patrimonioLocalizacaoController.getpatrimonioLocalizacao
+);
+routes.get(
+    "/patrimonioLocalizacao/:id",
+    checkPermissions("movimentacao_financeira_visualizar"),
+    patrimonioLocalizacaoController.getpatrimonioLocalizacaoById
+);
+routes.delete(
+    "/patrimonioLocalizacao/delete/:id",
+    checkPermissions("movimentacao_financeira_deletar"),
+    patrimonioLocalizacaoController.deletepatrimonioLocalizacaoById
+);
+routes.patch(
+    "/patrimonioLocalizacao/update/:id",
+    checkPermissions("movimentacao_financeira_editar"),
+    patrimonioLocalizacaoController.updatepatrimonioLocalizacaoById
 );
 
 module.exports = routes;

--- a/src/routes.js
+++ b/src/routes.js
@@ -5,8 +5,8 @@ const supplierFormController = require("./Controllers/supplierFormController");
 const financialMovementsController = require("./Controllers/financialMovementsController");
 const patrimonioController = require("./Controllers/patrimonioController");
 const financialReportController = require("./Controllers/financialReportController");
-const patrimonioLocalizacaoController = require("./Controllers/patrimonioLocalizacaoController")
-const LocalizacaoController = require("./Controllers/LocalizacaoController")
+const patrimonioLocalizacaoController = require("./Controllers/patrimonioLocalizacaoController");
+const LocalizacaoController = require("./Controllers/LocalizacaoController");
 const { checkPermissions } = require("./Middlewares/accessControlMiddleware");
 
 // Rotas Contas Bancárias

--- a/src/routes.js
+++ b/src/routes.js
@@ -6,6 +6,7 @@ const financialMovementsController = require("./Controllers/financialMovementsCo
 const patrimonioController = require("./Controllers/patrimonioController");
 const financialReportController = require("./Controllers/financialReportController");
 const patrimonioLocalizacaoController = require("./Controllers/patrimonioLocalizacaoController")
+const LocalizacaoController = require("./Controllers/LocalizacaoController")
 const { checkPermissions } = require("./Middlewares/accessControlMiddleware");
 
 // Rotas Contas Bancárias
@@ -144,6 +145,32 @@ routes.patch(
     "/patrimonioLocalizacao/update/:id",
     checkPermissions("movimentacao_financeira_editar"),
     patrimonioLocalizacaoController.updatepatrimonioLocalizacaoById
+);
+
+routes.post(
+    "/localizacao/create",
+    checkPermissions("movimentacao_financeira_criar"),
+    LocalizacaoController.createlocalizacao
+);
+routes.get(
+    "/localizacao",
+    checkPermissions("movimentacao_financeira_visualizar"),
+    LocalizacaoController.getlocalizacao
+);
+routes.get(
+    "/localizacao/:id",
+    checkPermissions("movimentacao_financeira_visualizar"),
+    LocalizacaoController.getlocalizacaoById
+);
+routes.delete(
+    "/localizacao/delete/:id",
+    checkPermissions("movimentacao_financeira_deletar"),
+    LocalizacaoController.deletelocalizacaoById
+);
+routes.patch(
+    "/localizacao/update/:id",
+    checkPermissions("movimentacao_financeira_editar"),
+    LocalizacaoController.updatelocalizacaoById
 );
 
 module.exports = routes;

--- a/src/routes.js
+++ b/src/routes.js
@@ -95,27 +95,27 @@ routes.post(
 //rotas patrimonio
 routes.post(
     "/patrimonio/create",
-    checkPermissions("patrimonio_criar"),
+    checkPermissions("movimentacao_financeira_criar"),
     patrimonioController.createpatrimonio
 );
 routes.get(
     "/patrimonio",
-    checkPermissions("patrimonio_visualizar"),
+    checkPermissions("movimentacao_financeira_visualizar"),
     patrimonioController.getpatrimonio
 );
 routes.get(
     "/patrimonio/:id",
-    checkPermissions("patrimonio_visualizar"),
+    checkPermissions("movimentacao_financeira_visualizar"),
     patrimonioController.getpatrimonioById
 );
 routes.delete(
     "/patrimonio/delete/:id",
-    checkPermissions("patrimonio_deletar"),
+    checkPermissions("movimentacao_financeira_deletar"),
     patrimonioController.deletepatrimonioById
 );
 routes.patch(
     "/patrimonio/update/:id",
-    checkPermissions("patrimonio_editar"),
+    checkPermissions("movimentacao_financeira_editar"),
     patrimonioController.updatepatrimonioById
 );
 

--- a/src/routes.js
+++ b/src/routes.js
@@ -3,6 +3,7 @@ const routes = express.Router();
 const bankAccountController = require("./Controllers/bankAccountController");
 const supplierFormController = require("./Controllers/supplierFormController");
 const financialMovementsController = require("./Controllers/financialMovementsController");
+const patrimonioController = require("./Controllers/patrimonioController");
 const financialReportController = require("./Controllers/financialReportController");
 const { checkPermissions } = require("./Middlewares/accessControlMiddleware");
 
@@ -90,6 +91,32 @@ routes.post(
     "/financialMovements/report",
     checkPermissions("movimentacao_financeira_visualizar"),
     financialReportController.generateFinancialReport
+);
+//rotas patrimonio
+routes.post(
+    "/patrimonio/create",
+    checkPermissions("patrimonio_criar"),
+    patrimonioController.createpatrimonio
+);
+routes.get(
+    "/patrimonio",
+    checkPermissions("patrimonio_visualizar"),
+    patrimonioController.getpatrimonio
+);
+routes.get(
+    "/patrimonio/:id",
+    checkPermissions("patrimonio_visualizar"),
+    patrimonioController.getpatrimonioById
+);
+routes.delete(
+    "/patrimonio/delete/:id",
+    checkPermissions("patrimonio_deletar"),
+    patrimonioController.deletepatrimonioById
+);
+routes.patch(
+    "/patrimonio/update/:id",
+    checkPermissions("patrimonio_editar"),
+    patrimonioController.updatepatrimonioById
 );
 
 module.exports = routes;


### PR DESCRIPTION
Descrição:
Como administrador, gostaria de cadastrar, visualizar, editar e deletar os patrimônios

Criterios de aceitação:

- [ ] O cadastro de patrimônio deve conter os campos: Nome, descrição, valor, número de série, etiqueta, localização, doação e data de cadastro.
- [ ] Patrimônios podem ser cadastrados com o mesmo nome.
- [ ] O número da etiqueta de patrimonio deve ser gerado automaticamente ao realizar o cadastro.
- [ ] O número da etiqueta de patrimonio deve conter 4 digitos e ser único.
- [ ] O número da etiqueta de patrimonio não pode ser alterado.
- [ ] O campo de localização deve ter as opções: Sala de comunicação, Jurídico, Presidência, Reunião, Recepção, Copa,  Sala de Podcast, Recepção do Podcast e Outros.
- [ ] A página de visualização e edição deve conter o histórico de movimentações entre localizações.
- [ ] A página de lista deve listar todos os patrimônios cadastrados.
- [ ] A lista de patrimonio deve mostrar os campos Nome, Etiqueta de patrimonio e Localização.
- [ ] A página de lista de patrimonio deve conter pesquisa por nome, número de etiqueta de patrimonio e filtro por localização.